### PR TITLE
Feature/support multiple env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules
-elm-constants.json
 src/**/*.*
 .env

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Populate it like this:
 ```
 {
   "path": "./path/to/elm/dir",
-  "envPath": "./path/to/env/dir",
   "moduleName": "Constants",
   "values": [
     ["SERVER_URL", "backendUrl"],
@@ -30,7 +29,6 @@ Populate it like this:
 }
 ```
 
-`envPath` is optional and defaults to current working directory.
 For the `values` field you can have either a regular string or an array with two values. If you specify
 a regular string, this tool will automatically convert it to a valid Elm variable name. In the case of `GOOGLE_API_KEY`,
 it would generate `googleApiKey`. If you're not happy with the generated name or just want to rename it anyways,
@@ -59,6 +57,7 @@ backendUrl =
 Options:
   --version, -v  Print the installed version                      [boolean]
   --no-dotenv    Dont' use dotenv                                 [boolean]
+  --path, -p     Path to env file                                 [string]
   --config, -c   Path to config file                              [string]
   --help, -h     Show help                                        [boolean]
 ```
@@ -69,7 +68,6 @@ The schema for the config file.
 
 ```
 { "path": : String
-, "envPath" ?: String
 , "moduleName" : String
 , "values" : [String, String] | String
 }
@@ -77,11 +75,9 @@ The schema for the config file.
 
 # Dotenv
 
-This package automatically works with [`dotenv`](https://github.com/motdotla/dotenv) and also extends it adding
-the hability to have multiple `.env*` files like `.env.development`, `.env.test` and so on.
-This will read environment variables from the `.env` located at provided `envPath` (or defaulting to current
-working directory). Additionally, if the `NODE_ENV` environment variable is set, then `.env.${NODE_ENV}` file is
-loaded.
+This package automatically works with [`dotenv`](https://github.com/motdotla/dotenv).
+By default this will look for an `.env` file at current working directory. Alternatively you 
+may provide a path flag (`--path`) for a custom file such as `--path=./env/.env.staging`.
 If you run `elm-constants` in and `NODE_ENV` is **not** `production`, then this tool automatically loads that file.
 
 If you want to turn this off, just pass `--no-dotenv` to `elm-constants`

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ backendUrl =
 # CLI Options
 ```
 Options:
-  --version, -v  Print the installed version                      [boolean]
-  --no-dotenv    Dont' use dotenv                                 [boolean]
-  --path, -p     Path to env file                                 [string]
-  --config, -c   Path to config file                              [string]
-  --help, -h     Show help                                        [boolean]
+  --version, -v     Print the installed version                  [boolean]
+  --no-dotenv       Dont' use dotenv                             [boolean]
+  --env-path, -p    Path to env file                             [string]
+  --config, -c      Path to config file                          [string]
+  --help, -h        Show help                                    [boolean]
 ```
 
 ## Config Schema
@@ -77,7 +77,7 @@ The schema for the config file.
 
 This package automatically works with [`dotenv`](https://github.com/motdotla/dotenv).
 By default this will look for an `.env` file at current working directory. Alternatively you 
-may provide a path flag (`--path`) for a custom file such as `--path=./env/.env.staging`.
+may provide a path flag (`--env-path`) for a custom file such as `--env-path=./env/.env.staging`.
 If you run `elm-constants` in and `NODE_ENV` is **not** `production`, then this tool automatically loads that file.
 
 If you want to turn this off, just pass `--no-dotenv` to `elm-constants`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Populate it like this:
 ```
 {
   "path": "./path/to/elm/dir",
+  "envPath": "./path/to/env/dir",
   "moduleName": "Constants",
   "values": [
     ["SERVER_URL", "backendUrl"],
@@ -29,6 +30,7 @@ Populate it like this:
 }
 ```
 
+`envPath` is optional and defaults to current working directory.
 For the `values` field you can have either a regular string or an array with two values. If you specify
 a regular string, this tool will automatically convert it to a valid Elm variable name. In the case of `GOOGLE_API_KEY`,
 it would generate `googleApiKey`. If you're not happy with the generated name or just want to rename it anyways,
@@ -66,17 +68,21 @@ Options:
 The schema for the config file.
 
 ```
-{ "path: : String
+{ "path": : String
+, "envPath" ?: String
 , "moduleName" : String
-, "values" : [string, string] | string
+, "values" : [String, String] | String
 }
 ```
 
 # Dotenv
 
-This package automatically works with [`dotenv`](https://github.com/motdotla/dotenv), a tool to let you specify
-development environment variables in file at the root of your project. If you have a file `.env` in the directory
-you run `elm-constants` in and `NODE_ENV` is **not** `production`, then this tool automatically loads that file.
+This package automatically works with [`dotenv`](https://github.com/motdotla/dotenv) and also extends it adding
+the hability to have multiple `.env*` files like `.env.development`, `.env.test` and so on.
+This will read environment variables from the `.env` located at provided `envPath` (or defaulting to current
+working directory). Additionally, if the `NODE_ENV` environment variable is set, then `.env.${NODE_ENV}` file is
+loaded.
+If you run `elm-constants` in and `NODE_ENV` is **not** `production`, then this tool automatically loads that file.
 
 If you want to turn this off, just pass `--no-dotenv` to `elm-constants`
 

--- a/example-multiple-env/Constants.elm
+++ b/example-multiple-env/Constants.elm
@@ -1,0 +1,11 @@
+module Constants exposing (googleApiKey, serverUrl)
+
+
+googleApiKey : String
+googleApiKey =
+    "apiKeyTest"
+
+
+serverUrl : String
+serverUrl =
+    "serverTest"

--- a/example-multiple-env/elm-constants.json
+++ b/example-multiple-env/elm-constants.json
@@ -1,0 +1,9 @@
+{
+  "path": ".",
+  "envPath": "./env",
+  "moduleName": "Constants",
+  "values": [
+    ["SERVER_URL", "serverUrl"],
+    "GOOGLE_API_KEY"
+  ]
+}

--- a/example-multiple-env/elm-constants.json
+++ b/example-multiple-env/elm-constants.json
@@ -1,6 +1,5 @@
 {
   "path": ".",
-  "envPath": "./env",
   "moduleName": "Constants",
   "values": [
     ["SERVER_URL", "serverUrl"],

--- a/example-multiple-env/env/.env.development
+++ b/example-multiple-env/env/.env.development
@@ -1,0 +1,2 @@
+SERVER_URL=serverDevelopment
+GOOGLE_API_KEY=apiKeyDevelopment

--- a/example-multiple-env/env/.env.test
+++ b/example-multiple-env/env/.env.test
@@ -1,0 +1,2 @@
+SERVER_URL=serverTest
+GOOGLE_API_KEY=apiKeyTest

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const argv = yargs
     description: "Dont' use dotenv",
     type: "boolean"
   })
-  .option("path", {
+  .option("env-path", {
     alias: "p",
     description: "Path to env file",
     type: "string",
@@ -79,14 +79,14 @@ try {
 
   if (typeof argv.dotenv !== "boolean" || argv.dotenv !== false) {
     let envPath = path.resolve(process.cwd(), '.env');
-    if (typeof argv.path === "string") {
+    if (typeof argv.envPath === "string") {
       const PATH_REGEXP = /^.*\.(env)($|\..+$)/;
-      if (!fs.existsSync(argv.path) || !PATH_REGEXP.test(argv.path)) {
+      if (!fs.existsSync(argv.envPath) || !PATH_REGEXP.test(argv.envPath)) {
         throw new Error(
-          `I couldn't find an env file at "${argv.path}"`
+          `I couldn't find an env file at "${argv.envPath}"`
         );
       }
-      envPath = argv.path;
+      envPath = argv.envPath;
     }
 
     if (process.env.NODE_ENV !== "production") {

--- a/index.js
+++ b/index.js
@@ -27,12 +27,6 @@ if (argv.version) {
   console.log(version);
 }
 
-if (typeof argv.dotenv !== "boolean" || argv.dotenv !== false) {
-  if (process.env.NODE_ENV !== "production") {
-    require("dotenv").config();
-  }
-}
-
 let config;
 try {
   const configFilePath = path.normalize(
@@ -76,6 +70,27 @@ try {
       'The field "values" in the config file was empty. ' +
         "There's nothing for me to do!"
     );
+  }
+
+  if (typeof argv.dotenv !== "boolean" || argv.dotenv !== false) {
+    const envPath = config.envPath || process.cwd();
+    let envFileName = '.env';
+    if (process.env.NODE_ENV) {
+      envFileName += `.${process.env.NODE_ENV}`;
+    }
+
+    const envFilePath = path.resolve(envPath, envFileName);
+    if (!fs.existsSync(envFilePath)) {
+      throw new Error(
+        `I couldn't find "${envFileName}" file at "${envPath}"`
+      );
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      require("dotenv").config({
+        path: envFilePath,
+      });
+    }
   }
 
   const isValidElmVar = str => new RegExp(/^[a-z]\w+$/).test(str);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,11 @@ const argv = yargs
     description: "Dont' use dotenv",
     type: "boolean"
   })
+  .option("path", {
+    alias: "p",
+    description: "Path to env file",
+    type: "string",
+  })
   .option("config", {
     alias: "c",
     description: "Path to config file",
@@ -73,22 +78,20 @@ try {
   }
 
   if (typeof argv.dotenv !== "boolean" || argv.dotenv !== false) {
-    const envPath = config.envPath || process.cwd();
-    let envFileName = '.env';
-    if (process.env.NODE_ENV) {
-      envFileName += `.${process.env.NODE_ENV}`;
-    }
-
-    const envFilePath = path.resolve(envPath, envFileName);
-    if (!fs.existsSync(envFilePath)) {
-      throw new Error(
-        `I couldn't find "${envFileName}" file at "${envPath}"`
-      );
+    let envPath = path.resolve(process.cwd(), '.env');
+    if (typeof argv.path === "string") {
+      const PATH_REGEXP = /^.*\.(env)($|\..+$)/;
+      if (!fs.existsSync(argv.path) || !PATH_REGEXP.test(argv.path)) {
+        throw new Error(
+          `I couldn't find an env file at "${argv.path}"`
+        );
+      }
+      envPath = argv.path;
     }
 
     if (process.env.NODE_ENV !== "production") {
       require("dotenv").config({
-        path: envFilePath,
+        path: envPath,
       });
     }
   }


### PR DESCRIPTION
Use case:
I want to be able to load different `.env` files according to my target (staging, test, mock, etc).
When multiple `.env` files exists, they are most likely in a specific folder instead of the root directory, therefore I should be able to provide a path to my `.env` files in `elm-constants.json`.